### PR TITLE
Fixed an bug where some customclaims that look like Epoch times were causing some system errors

### DIFF
--- a/src/components/Decoded/Decoded.tsx
+++ b/src/components/Decoded/Decoded.tsx
@@ -26,8 +26,8 @@ const Decoded: React.FC<{
   const [showExplained, setShowExplained] = useState(false);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const isValidDate = useCallback((value: any): boolean => {
-    return isValid(value);
+  const isValidDate = useCallback((value: any, key: string): boolean => {
+    return ['iat', 'exp'].includes(key) && isValid(value);
   }, []);
 
   const [selectedAlgorithm, setSelectedAlgorithm] = React.useState<
@@ -174,7 +174,7 @@ const Decoded: React.FC<{
               <br />
               {payload
                 ? Object.entries(payload).map(([key, value]) => {
-                    const isDate = isValidDate(value);
+                    const isDate = isValidDate(value, key);
 
                     let valuePrefix = '';
                     if (key === 'exp') {

--- a/src/providers/engine.ts
+++ b/src/providers/engine.ts
@@ -24,13 +24,18 @@ export type ClaimMatcher = {
 }
 
 export function detectProvider(token: string): TokenProvider | null {
-    const tokenPayload = decodeJwt(token);
-    for (const provider of providers) {
-        if (provider.match.some(match => matchToken(tokenPayload, match))) {
-            return provider;
+    try {
+        const tokenPayload = decodeJwt(token);
+        for (const provider of providers) {
+            if (provider.match.some(match => matchToken(tokenPayload, match))) {
+                return provider;
+            }
         }
+        return null;
+    } catch (e) {
+        // Silently handle invalid JWT
+        return null;
     }
-    return null;
 }
 
 function matchToken(tokenPayload: JWTPayload, match: TokenMatch): boolean {


### PR DESCRIPTION
Fixed a bug that was causing the app to crash when a custom claim looked like an Epoch date but was not valid (since it was not intended to be a date).

I fixed it by only translating the `iss` and `exp` dates into human-readable and ignoring the rest. 

The second commit helps with some uncaught errors, it was not causing crashes, but cleans up the console a bit. 